### PR TITLE
feat: Add keyboard shortcuts for core extension actions

### DIFF
--- a/background.js
+++ b/background.js
@@ -24,19 +24,89 @@ function createContextMenus() {
   });
 }
 
+function searchTextIncognito(selectionText) {
+  if (selectionText) {
+    chrome.windows.create({"url": `https://www.google.com/search?q=${selectionText}`, "incognito": true});
+  }
+}
+
+function openPageIncognito(pageUrl) {
+  if (pageUrl) {
+    chrome.windows.create({"url": pageUrl, "incognito": true});
+  }
+}
+
+function openLinkIncognito(linkUrl) {
+  if (linkUrl) {
+    chrome.windows.create({"url": linkUrl, "incognito": true});
+  }
+}
+
 function onContextMenuClicked(clickData)
 {
   if(clickData.menuItemId == "selectionContextMenu" && clickData.selectionText)
   {
-    chrome.windows.create({"url": `https://www.google.com/search?q=${clickData.selectionText}`, "incognito": true});
+    searchTextIncognito(clickData.selectionText);
   }
   else if(clickData.menuItemId == "pageContextMenu")
   {
-    chrome.windows.create({"url": clickData.pageUrl, "incognito": true});
+    openPageIncognito(clickData.pageUrl);
   }
   else if(clickData.menuItemId == "linkContextMenu")
   {
-    chrome.windows.create({"url": clickData.linkUrl, "incognito": true});
+    openLinkIncognito(clickData.linkUrl);
   }
-
 }
+
+chrome.commands.onCommand.addListener((command, tab) => {
+  if (command === "open_page_incognito") {
+    if (tab && tab.url) {
+      openPageIncognito(tab.url);
+    } else {
+      // Fallback if tab is not directly available or doesn't have a URL
+      chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
+        if (tabs && tabs.length > 0 && tabs[0].url) {
+          openPageIncognito(tabs[0].url);
+        } else {
+          console.log("Open page shortcut: Could not determine active tab URL.");
+        }
+      });
+    }
+  } else if (command === "search_text_incognito") {
+    // Attempt to get selected text using executeScript
+    // Note: executeScript requires "scripting" permission or host permissions for the active tab.
+    // Assuming "scripting" permission is added to manifest.json if this approach is chosen.
+    if (tab && tab.id) {
+        chrome.scripting.executeScript({
+            target: {tabId: tab.id},
+            func: () => window.getSelection().toString()
+        }, (injectionResults) => {
+            if (injectionResults && injectionResults.length > 0 && injectionResults[0].result) {
+                searchTextIncognito(injectionResults[0].result);
+            } else {
+                console.log("Search text shortcut: Could not retrieve selected text. Ensure text is selected, or this might require 'scripting' permission and a content script.");
+            }
+        });
+    } else {
+         // Fallback for when tab context is not directly available (e.g. global shortcut)
+        chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
+            if (tabs && tabs.length > 0 && tabs[0].id) {
+                chrome.scripting.executeScript({
+                    target: {tabId: tabs[0].id},
+                    func: () => window.getSelection().toString()
+                }, (injectionResults) => {
+                    if (injectionResults && injectionResults.length > 0 && injectionResults[0].result) {
+                        searchTextIncognito(injectionResults[0].result);
+                    } else {
+                        console.log("Search text shortcut: Could not retrieve selected text from active tab. Ensure text is selected or permissions are correctly set.");
+                    }
+                });
+            } else {
+                console.log("Search text shortcut: No active tab found to get selection from.");
+            }
+        });
+    }
+  } else if (command === "open_link_incognito") {
+    console.log("Open link shortcut triggered, but this requires context (e.g., a selected link from a content script) which is not directly available here for a global shortcut. This command is more suitable for context menus or direct interaction with page content.");
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
         "service_worker": "background.js"
     },
     "permissions": [
-        "contextMenus", "tabs"
+        "contextMenus", "tabs", "scripting"
     ],
     "action": {
         "default_popup": "popup.html",
@@ -23,5 +23,28 @@
         "32": "/images/INcognito_logo_32.png",
         "48": "/images/INcognito_logo_48.png",
         "128": "/images/INcognito_logo_128.png"
+    },
+    "commands": {
+        "open_link_incognito": {
+            "suggested_key": {
+                "default": "Ctrl+Shift+L",
+                "mac": "MacCtrl+Shift+L"
+            },
+            "description": "Open the selected link in an incognito window"
+        },
+        "search_text_incognito": {
+            "suggested_key": {
+                "default": "Ctrl+Shift+S",
+                "mac": "MacCtrl+Shift+S"
+            },
+            "description": "Search the selected text in an incognito window"
+        },
+        "open_page_incognito": {
+            "suggested_key": {
+                "default": "Ctrl+Shift+P",
+                "mac": "MacCtrl+Shift+P"
+            },
+            "description": "Open the current page in an incognito window"
+        }
     }
 }


### PR DESCRIPTION
This commit introduces keyboard shortcuts for the primary functionalities of the Open INcognito extension, enhancing your productivity and accessibility.

The following shortcuts have been added:
- Open Current Page INcognito: Ctrl+Shift+P (Cmd+Shift+P on Mac)
- Search Selected Text INcognito: Ctrl+Shift+S (Cmd+Shift+S on Mac)
- Open Link INcognito: Ctrl+Shift+L (Cmd+Shift+L on Mac)

Changes include:
- Modified `manifest.json` to define the `commands` and add the `scripting` permission (required for accessing selected text).
- Updated `background.js` to:
    - Refactor context menu click handlers into reusable functions (`openPageIncognito`, `searchTextIncognito`, `openLinkIncognito`).
    - Add a `chrome.commands.onCommand` listener to handle the new keyboard shortcuts.
    - The `open_link_incognito` command logs a message to the console, as it requires page context that isn't directly available to a global shortcut handler without a more complex content script strategy. The context menu option for this remains fully functional.
    - The `search_text_incognito` command now uses `chrome.scripting.executeScript` to retrieve the selected text from the active page.

The existing context menu functionality remains unchanged and operational. These shortcuts provide an alternative way to access the extension's features quickly.